### PR TITLE
chore: update label parsing logic

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -29,7 +29,6 @@ runs:
         IFS=',' read -a labels_as_array <<< "$labels_array"
         filtered_array=()
         for item in ${labels_as_array[@]}; do
-            echo $item
             if [[ $item == "fix" || $item == "compatible" || $item == "breaking" ]]; then
                 filtered_array+=($item)
             fi

--- a/action.yaml
+++ b/action.yaml
@@ -26,13 +26,13 @@ runs:
         echo "$labels"
         # Parse the labels that are relevant for versioning into an array
         labels_array=$(jq -r '. | map(.name) | join(",")' <(echo "$labels"))
-        filtered_array=()
-        for item in "${labels_array[@]}"; do
-            if [[ "$item" == "fix" || "$item" == "compatible" || "$item" == "breaking" ]]; then
-                filtered_array+=("$item")
-            fi
-        done
-        labels_array=${filtered_array[@]};
+        # filtered_array=()
+        # for item in "${labels_array[@]}"; do
+            # if [[ "$item" == "fix" || "$item" == "compatible" || "$item" == "breaking" ]]; then
+                # filtered_array+=("$item")
+            # fi
+        # done
+        # labels_array=${filtered_array[@]};
         echo "$labels_array"
         # Check if the labels contain only one instance of "fix", "compatible", or "breaking"
         count=$(echo "${labels_array[@]}" | grep -Eo "\b(fix|compatible|breaking)\b" | wc -l)

--- a/action.yaml
+++ b/action.yaml
@@ -27,7 +27,8 @@ runs:
         # Parse the labels that are relevant for versioning into an array
         labels_array=$(jq -r '. | map(.name) | join(",")' <(echo "$labels"))
         filtered_array=()
-        for item in ${labels_array[@]}; do
+        IFS=',' read -a labels_as_array <<< "$labels_array"
+        for item in ${labels_as_array[@]}; do
             echo $item
             if [[ $item == "fix" || $item == "compatible" || $item == "breaking" ]]; then
                 filtered_array+=($item)

--- a/action.yaml
+++ b/action.yaml
@@ -24,10 +24,17 @@ runs:
       run: |
         labels=$(curl -s -H "Authorization: token ${{ inputs.github_token }}" https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels)
         echo "$labels"
-        # Parse the labels into an array
+        # Parse the labels that are relevant for versioning into an array
         labels_array=$(jq -r '. | map(.name) | join(",")' <(echo "$labels"))
+        filtered_array=()
+        for item in "${labels_array[@]}"; do
+            if [[ "$item" == "fix" || "$item" == "compatible" || "$item" == "breaking" ]]; then
+                filtered_array+=("$item")
+            fi
+        done
+        labels_array=${filtered_array[@]};
         echo "$labels_array"
-        # Check if the labels contain "fix", "compatible", or "breaking"
+        # Check if the labels contain only one instance of "fix", "compatible", or "breaking"
         count=$(echo "${labels_array[@]}" | grep -Eo "\b(fix|compatible|breaking)\b" | wc -l)
         if ! [ "$count" -eq 1 ]; then
           echo "Error: Invalid labels found. Only one of 'fix', 'compatible', or 'breaking' is allowed."

--- a/action.yaml
+++ b/action.yaml
@@ -27,9 +27,10 @@ runs:
         # Parse the labels that are relevant for versioning into an array
         labels_array=$(jq -r '. | map(.name) | join(",")' <(echo "$labels"))
         filtered_array=()
-        for item in "${labels_array[@]}"; do
-            if [[ "$item" == "fix" || "$item" == "compatible" || "$item" == "breaking" ]]; then
-                filtered_array+=("$item")
+        for item in ${labels_array[@]}; do
+            echo $item
+            if [[ $item == "fix" || $item == "compatible" || $item == "breaking" ]]; then
+                filtered_array+=($item)
             fi
         done
         echo "$filtered_array"

--- a/action.yaml
+++ b/action.yaml
@@ -26,12 +26,13 @@ runs:
         echo "$labels"
         # Parse the labels that are relevant for versioning into an array
         labels_array=$(jq -r '. | map(.name) | join(",")' <(echo "$labels"))
-        # filtered_array=()
-        # for item in "${labels_array[@]}"; do
-            # if [[ "$item" == "fix" || "$item" == "compatible" || "$item" == "breaking" ]]; then
-                # filtered_array+=("$item")
-            # fi
-        # done
+        filtered_array=()
+        for item in "${labels_array[@]}"; do
+            if [[ "$item" == "fix" || "$item" == "compatible" || "$item" == "breaking" ]]; then
+                filtered_array+=("$item")
+            fi
+        done
+        echo "$filtered_array"
         # labels_array=${filtered_array[@]};
         echo "$labels_array"
         # Check if the labels contain only one instance of "fix", "compatible", or "breaking"

--- a/action.yaml
+++ b/action.yaml
@@ -26,16 +26,15 @@ runs:
         echo "$labels"
         # Parse the labels that are relevant for versioning into an array
         labels_array=$(jq -r '. | map(.name) | join(",")' <(echo "$labels"))
-        filtered_array=()
         IFS=',' read -a labels_as_array <<< "$labels_array"
+        filtered_array=()
         for item in ${labels_as_array[@]}; do
             echo $item
             if [[ $item == "fix" || $item == "compatible" || $item == "breaking" ]]; then
                 filtered_array+=($item)
             fi
         done
-        echo "$filtered_array"
-        # labels_array=${filtered_array[@]};
+        labels_array="${filtered_array[*]}";
         echo "$labels_array"
         # Check if the labels contain only one instance of "fix", "compatible", or "breaking"
         count=$(echo "${labels_array[@]}" | grep -Eo "\b(fix|compatible|breaking)\b" | wc -l)


### PR DESCRIPTION
Refine label parsing to focus on relevant labels for versioning and enforce a single instance check for 'fix', 'compatible', or 'breaking'.
This change enables the checked PR to have multiple other labels. You can check the change in an example PR of the SPA repo:
| Scenario | Before | After | Example |
| --- | --- | --- | --- |
| Single relevant label | ✅ | ✅ | [example](https://github.com/yaos/LimeFlightSPA/actions/runs/18876110963/job/53870374166?pr=3749) |
| Multiple labels, only one relevant label | ❌ | ✅ | [example](https://github.com/yaos/LimeFlightSPA/actions/runs/18876110963/job/53869070542?pr=3749) |
| Multiple labels,  multiple relevant labels | ❌ | ❌ | [example](https://github.com/yaos/LimeFlightSPA/actions/runs/18876110963/job/53869295552?pr=3749) |
| No labels | ❌ | ❌ | [example](https://github.com/yaos/LimeFlightSPA/actions/runs/18876110963/job/53869576038?pr=3749) |
